### PR TITLE
Store service data in `main` to simplify backup/restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ ADD ./health-check.sh /usr/local/bin/health-check.sh
 RUN chmod a+x /usr/local/bin/docker_entrypoint.sh
 RUN chmod a+x /usr/local/bin/health-check.sh
 
-VOLUME /data
-
 EXPOSE 8000
 
 ENTRYPOINT ["docker_entrypoint.sh"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 ITCHYSATS_USER=itchysats
-ITCHYSATS_PASSWORD=$(yq e '.password' /root/start9/config.yaml)
+ITCHYSATS_PASSWORD=$(yq e '.password' /data/start9/config.yaml)
 
 # Properties page for username and password
 echo "version: 2
@@ -22,6 +22,6 @@ data:
     copyable: true
     masked: true
     qr: false
-" > /root/start9/stats.yaml
+" > /data/start9/stats.yaml
 
-exec itchysats --data-dir=/data --http-address=0.0.0.0:8000 --password=$ITCHYSATS_PASSWORD mainnet --electrum=electrs.embassy:50001
+exec itchysats --data-dir=/data/itchysats --http-address=0.0.0.0:8000 --password=$ITCHYSATS_PASSWORD mainnet --electrum=electrs.embassy:50001

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -29,8 +29,8 @@ main:
   entrypoint: "docker_entrypoint.sh"
   args: []
   mounts:
-    main: /root
-    data: /data
+    main: /data
+  io-format: yaml
 health-checks:
   web-ui:
     name: Web Interface
@@ -63,8 +63,6 @@ properties:
   type: script
 volumes:
   main:
-    type: data
-  data:
     type: data
 interfaces:
   main:
@@ -102,7 +100,8 @@ backup:
       - /data
     mounts:
       BACKUP: /mnt/backup
-      data: /data
+      main: /data
+    io-format: yaml
   restore:
     type: docker
     image: compat
@@ -115,7 +114,8 @@ backup:
       - /data
     mounts:
       BACKUP: /mnt/backup
-      data: /data
+      main: /data
+    io-format: yaml
 migrations:
   from:
     "*":


### PR DESCRIPTION
Removes the separate `data` module and just stores the itchysats data in `main` in an `itchysats` folder next to the `start9` folder. This simplifies backup and restore because we only have to backup `main`.