### PR TITLE
Backup both `main` and `data`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION := $(shell yq e ".version" manifest.yaml)
 S9PK_PATH=$(shell find . -name itchysats.s9pk -print)
 TS_FILES := $(shell find . -name \*.ts )
+ASSET_PATHS := $(shell find ./assets/*)
 
 .DELETE_ON_ERROR:
 
@@ -16,7 +17,7 @@ clean:
 	rm -f image.tar
 	rm -f itchysats.s9pk
 
-itchysats.s9pk: manifest.yaml image.tar instructions.md scripts/embassy.js
+itchysats.s9pk: manifest.yaml image.tar instructions.md $(ASSET_PATHS) scripts/embassy.js
 	embassy-sdk pack
 
 image.tar: Dockerfile health-check.sh docker_entrypoint.sh

--- a/assets/compat/backup-create.sh
+++ b/assets/compat/backup-create.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+compat duplicity create /mnt/backup /root/start9 && compat duplicity create /mnt/backup /data

--- a/assets/compat/backup-restore.sh
+++ b/assets/compat/backup-restore.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+compat duplicity restore /mnt/backup /root/start9 && compat duplicity restore /mnt/backup /data

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -66,6 +66,8 @@ volumes:
     type: data
   data:
     type: data
+  compat:
+    type: assets
 interfaces:
   main:
     name: ItchySats Interface
@@ -94,28 +96,22 @@ backup:
     type: docker
     image: compat
     system: true
-    entrypoint: compat
-    args:
-      - duplicity
-      - create
-      - /mnt/backup
-      - /data
+    entrypoint: /mnt/assets/backup-create.sh
     mounts:
       BACKUP: /mnt/backup
+      main: /root/start9
       data: /data
+      compat: /mnt/assets
   restore:
     type: docker
     image: compat
     system: true
-    entrypoint: compat
-    args:
-      - duplicity
-      - restore
-      - /mnt/backup
-      - /data
+    entrypoint: /mnt/assets/backup-restore.sh
     mounts:
       BACKUP: /mnt/backup
+      main: /root/start9
       data: /data
+      compat: /mnt/assets
 migrations:
   from:
     "*":


### PR DESCRIPTION
fixes #7 

To achieve this we have to call `compat` for each volume to be backed up.

As pointed out by the start9 crew it's better to then configure a backup/restore script in the assets.