### PR TITLE
Custom electrs URL in case of Electrs problems

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -24,4 +24,10 @@ data:
     qr: false
 " > /root/start9/stats.yaml
 
-exec itchysats --data-dir=/data --http-address=0.0.0.0:8000 --password=$ITCHYSATS_PASSWORD mainnet --electrum=electrs.embassy:50001
+ELECTRS_URL=electrs.embassy:50001
+
+if [ "$(yq ".custom-electrs.enable-custom-electrs" /root/start9/config.yaml)" = "true" ]; then
+	ELECTRS_URL=$(yq e '.custom-electrs.electrs-url' /root/start9/config.yaml)
+fi
+
+exec itchysats --data-dir=/data --http-address=0.0.0.0:8000 --password=$ITCHYSATS_PASSWORD mainnet --electrum=$ELECTRS_URL

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,7 +1,14 @@
 # Configuration
 
-ItchySats on the Embassy requires a fully synced Electrum (electrs) node as a source for blockchain data. This requirement will be automatically enforced by EmbassyOS.
+ItchySats on the Embassy requires a fully synced Electrs node as a source for blockchain data. This requirement will be automatically enforced by EmbassyOS.
 The password can be found in the `Properties` section.
+
+## Custom Electrs in case of issues with Electrs
+
+In case you run into problems with your Electrs setup (e.g. you have to re-index because of a problem) it is possible to switch ItchySats to use a custom Electrs URL in the config.
+Be mindful when using this feature because you are not fully self-sovereign when using a public Electrs instance.
+Note that using a public Electrs instance doesn't pose a risk for your keys being stolen, but you won't have full privacy anymore.
+You should always prefer to use your embassy's Electrs instance and only activate a custom URL temporarily in case of issues.
 
 # ItchySats
 

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -24,5 +24,27 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
         "Must not contain newline or quote characters.",
     "copyable": true,
     "masked": true
-  }
+  },
+  "custom-electrs": {
+    "type": "object",
+    "name": "Custom Electrs",
+    "description": "Switch to a custom Electrum server instance. Be mindful activating this feature. Check the instructions for more information.",
+    "spec": {
+      "enable-custom-electrs": {
+        "name": "Enable Custom Electrs",
+        "description": "After enabling this you can specify a custom Electrs URL to be used below",
+        "type": "boolean",
+        "default": false,
+      },
+      "electrs-url": {
+        "type": "string" as const,
+        "name": "Custom Electrs URL",
+        "description": "URL to the Electrs instance to be used by ItchySats",
+        "nullable": false,
+        "default": "ssl://blockstream.info:700",
+        "copyable": true,
+        "masked": false
+      }
+    }
+  },
 });


### PR DESCRIPTION
Allow the user to specify a different Electrs URL in case of problems Without Electrs ItchySats cannot operate properly, which can mean that if a position was opened, but then Electrs has problems this position might get force-closed. To allow users to operate even if the Bitcoind / Electrs setup on their embassy makes problems we allow specifying a custom Electrs URL and specify a public blockcstream instance as default.

Looks like this:

![image](https://user-images.githubusercontent.com/5557790/194290844-b93e5fb3-4866-44dd-816b-5a5ac220584f.png)

---

Note: I needed this feature for testing because I was not able to properly start the container because ItchySats is currently not very resilient against Electrs not being available.
I opened this discussion to improve this: https://github.com/itchysats/itchysats/discussions/3129

Since the feature is generally useful to have I opted for creating a PR :)